### PR TITLE
Tests inputs/outputs folders relative to project test files

### DIFF
--- a/elwood/elwood.py
+++ b/elwood/elwood.py
@@ -315,7 +315,7 @@ class mixdata:
 def optimize_df_types(df: pd.DataFrame):
     """
     Pandas will upcast essentially everything. This will use the built-in
-    Pandas function to_numeeric to downcast dataframe series to types that use
+    Pandas function to_numeric to downcast dataframe series to types that use
     less memory e.g. float64 to float32.
 
     For very large dataframes the memory reduction should translate into

--- a/tests/elwood_unit_test.py
+++ b/tests/elwood_unit_test.py
@@ -2,7 +2,6 @@
 
 """Tests for `elwood` package."""
 
-
 import unittest
 import warnings
 import subprocess
@@ -11,16 +10,27 @@ import json
 import gc
 import os
 
+from pathlib import Path
+
 from elwood import elwood
 from pandas.util.testing import assert_frame_equal, assert_dict_equal
 import pandas as pd
 
-if os.name == "nt":
-    sep = "\\"
-else:
-    sep = "/"
+def get_project_root() -> Path:
+    return Path(__file__).parent.parent
 
 logger = logging.getLogger(__name__)
+
+from os.path import join as path_join
+
+inputs_base_dir = path_join(get_project_root(), "tests", "inputs")
+outputs_base_dir = path_join(get_project_root(), "tests", "outputs")
+
+def input_path(filename):
+    return path_join(inputs_base_dir, filename)
+
+def output_path(filename):
+    return path_join(outputs_base_dir, filename)
 
 
 class TestMixmaster(unittest.TestCase):
@@ -37,32 +47,34 @@ class TestMixmaster(unittest.TestCase):
         gc.collect()
         # Delete any output parquet files.
         try:
-            os.remove(f"outputs{sep}unittests.parquet.gzip")
-        except:
+            os.remove(output_path("unittests.parquet.gzip"))
+        except FileNotFoundError as e:
+            # print(f"tearDown: Exception caught while trying to empty test output files: {type(e)}")
             pass
 
         try:
-            os.remove(f"outputs{sep}unittests_str.parquet.gzip")
-        except:
+            os.remove(output_path("unittests_str.parquet.gzip"))
+        except FileNotFoundError as e:
+            # print(f"tearDown: Exception caught while trying to empty test output files: {type(e)}")
             pass
 
     def test_001_process(self):
         """Test ISO2 primary_geo; build a date day, month, year; no primary_date; feature qualifies another feature."""
 
         # Define elwood inputs:
-        mp = f"inputs{sep}test1_input.json"
-        fp = f"inputs{sep}test1_input.csv"
+        mp = input_path("test1_input.json") # mapper
+        fp = input_path("test1_input.csv")  # file
         geo = "admin2"
-        outf = f"outputs{sep}unittests"
+        outf = output_path("unittests")
 
         # Process:
         df, dct = elwood.process(fp, mp, geo, outf)
 
         # Load expected output:
-        output_df = pd.read_csv(f"outputs{sep}test1_output.csv", index_col=False)
+        output_df = pd.read_csv(output_path("test1_output.csv"), index_col=False)
         output_df = elwood.optimize_df_types(output_df)
 
-        # Sort both data frames and reindex for comparison,.
+        # Sort both data frames and reindex for comparison
         cols = [
             "timestamp",
             "country",
@@ -76,11 +88,13 @@ class TestMixmaster(unittest.TestCase):
         ]
         df.sort_values(by=cols, inplace=True)
         output_df.sort_values(by=cols, inplace=True)
+
         df.reset_index(drop=True, inplace=True)
         output_df.reset_index(drop=True, inplace=True)
 
         # Assertions
         assert_frame_equal(df, output_df)
+
 
     def test_002_process(self):
         """
@@ -90,10 +104,10 @@ class TestMixmaster(unittest.TestCase):
         """
 
         # Define elwood inputs:
-        mp = f"inputs{sep}test2_assetwealth_input.json"
-        fp = f"inputs{sep}test2_assetwealth_input.tif"
+        mp = input_path("test2_assetwealth_input.json")
+        fp = input_path("test2_assetwealth_input.tif")
         geo = "admin2"
-        outf = f"outputs{sep}unittests"
+        outf = output_path("unittests") # out folder
 
         # Process:
         df, dct = elwood.process(fp, mp, geo, outf)
@@ -102,10 +116,10 @@ class TestMixmaster(unittest.TestCase):
 
         # Load expected output:
         output_df = pd.read_csv(
-            f"outputs{sep}test2_assetwealth_output.csv", index_col=False
+            output_path("test2_assetwealth_output.csv"), index_col=False
         )
 
-        with open(f"outputs{sep}test2_assetwealth_dict.json") as f:
+        with open(output_path("test2_assetwealth_dict.json")) as f:
             output_dict = json.loads(f.read())
 
         # Sort both data frames and reindex for comparison,.
@@ -150,20 +164,20 @@ class TestMixmaster(unittest.TestCase):
         """Test qualifies, lat/lng primary geo."""
 
         # Define elwood inputs:
-        mp = f"inputs{sep}test3_qualifies.json"
-        fp = f"inputs{sep}test3_qualifies.csv"
+        mp = input_path("test3_qualifies.json")
+        fp = input_path("test3_qualifies.csv")
         geo = "admin2"
-        outf = f"outputs{sep}unittests"
+        outf = output_path("unittests")
 
         # Process:
         df, dct = elwood.process(fp, mp, geo, outf)
 
         # Load expected output:
         output_df = pd.read_csv(
-            f"outputs{sep}test3_qualifies_output.csv", index_col=False
+            output_path("test3_qualifies_output.csv"), index_col=False
         )
         output_df = elwood.optimize_df_types(output_df)
-        with open(f"outputs{sep}test3_qualifies_dict.json") as f:
+        with open(output_path("test3_qualifies_dict.json")) as f:
             output_dict = json.loads(f.read())
 
         # Sort both data frames and reindex for comparison,.
@@ -200,20 +214,20 @@ class TestMixmaster(unittest.TestCase):
         print("TEST 4 START")
 
         # Define elwood inputs:
-        mp = f"inputs{sep}test4_rainfall_error.json"
-        fp = f"inputs{sep}test4_rainfall_error.xlsx"
+        mp = input_path("test4_rainfall_error.json")
+        fp = input_path("test4_rainfall_error.xlsx")
         geo = "admin2"
-        outf = f"outputs{sep}unittests"
+        outf = output_path("unittests")
 
         # Process:
         df, dct = elwood.process(fp, mp, geo, outf)
 
         # Load expected output:
         output_df = pd.read_csv(
-            f"outputs{sep}test4_rainfall_error_output.csv", index_col=False
+            output_path("test4_rainfall_error_output.csv"), index_col=False
         )
         output_df = elwood.optimize_df_types(output_df)
-        with open(f"outputs{sep}test4_rainfall_error_dict.json") as f:
+        with open(output_path("test4_rainfall_error_dict.json")) as f:
             output_dict = json.loads(f.read())
 
         # Sort both data frames and reindex for comparison,.
@@ -293,13 +307,13 @@ class TestMixmaster(unittest.TestCase):
 
         # Run causemosify-multi
         inputs = (
-            '--inputs=[{"input_file": "inputs'
-            + f'{sep}test1_input.csv","mapper": "inputs{sep}test1_input.json"'
+            '--inputs=[{"input_file": "'
+            + f'{input_path("test1_input.csv")}","mapper": "{input_path("test1_input.json")}"'
             + '},{"input_file": "'
         )
         inputs = (
             inputs
-            + f'inputs{sep}test3_qualifies.csv","mapper": "inputs{sep}test3_qualifies.json"'
+            + f'{input_path("test3_qualifies.csv")}","mapper": "{input_path("test3_qualifies.json")}"'
             + "}]"
         )
         result = subprocess.run(
@@ -308,7 +322,7 @@ class TestMixmaster(unittest.TestCase):
                 "causemosify-multi",
                 inputs,
                 "--geo=admin2",
-                f"--output-file=outputs{sep}unittests",
+                f"--output-file={output_path('unittests')}",
             ],
             capture_output=True,
             encoding="utf-8",
@@ -318,10 +332,10 @@ class TestMixmaster(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
 
         ## Compare parquet files.
-        df1 = pd.read_parquet(f"outputs{sep}unittests.1.parquet.gzip")
-        df2 = pd.read_parquet(f"outputs{sep}unittests.2.parquet.gzip")
+        df1 = pd.read_parquet(output_path("unittests.1.parquet.gzip"))
+        df2 = pd.read_parquet(output_path("unittests.2.parquet.gzip"))
         df = df1.append(df2)
-        output_df = pd.read_parquet(f"outputs{sep}test5.parquet.gzip")
+        output_df = pd.read_parquet(output_path("test5.parquet.gzip"))
 
         # Sort both data frames and reindex for comparison,.
         cols = [
@@ -347,8 +361,8 @@ class TestMixmaster(unittest.TestCase):
         assert_frame_equal(df, output_df, check_categorical=False)
 
         ## Compare str.parquet file.
-        df = pd.read_parquet(f"outputs{sep}unittests_str.2.parquet.gzip")
-        output_df = pd.read_parquet(f"outputs{sep}test5_str.parquet.gzip")
+        df = pd.read_parquet(output_path("unittests_str.2.parquet.gzip"))
+        output_df = pd.read_parquet(output_path("test5_str.parquet.gzip"))
 
         # Sort both data frames and reindex for comparison,.
         cols = [
@@ -374,20 +388,20 @@ class TestMixmaster(unittest.TestCase):
         """Test multi primary_geo, resolve_to_gadm"""
 
         # Define elwood inputs:
-        mp = f"inputs{sep}test6_hoa_conflict_input.json"
-        fp = f"inputs{sep}test6_hoa_conflict_input.csv"
+        mp = input_path("test6_hoa_conflict_input.json")
+        fp = input_path("test6_hoa_conflict_input.csv")
         geo = "admin2"
-        outf = f"outputs{sep}unittests"
+        outf = output_path("unittests")
 
         # Process:
         df, dct = elwood.process(fp, mp, geo, outf)
 
         # Load expected output:
         output_df = pd.read_csv(
-            f"outputs{sep}test6_hoa_conflict_output.csv", index_col=False
+            output_path("test6_hoa_conflict_output.csv"), index_col=False
         )
         output_df = elwood.optimize_df_types(output_df)
-        with open(f"outputs{sep}test6_hoa_conflict_dict.json") as f:
+        with open(output_path("test6_hoa_conflict_dict.json")) as f:
             output_dict = json.loads(f.read())
 
         # Sort both data frames and reindex for comparison,.
@@ -422,10 +436,10 @@ class TestMixmaster(unittest.TestCase):
         """This tests single-band geotiff processing."""
 
         # Define elwood inputs:
-        mp = f"inputs{sep}test7_single_band_tif_input.json"
-        fp = f"inputs{sep}test7_single_band_tif_input.tif"
+        mp = input_path("test7_single_band_tif_input.json")
+        fp = input_path("test7_single_band_tif_input.tif")
         geo = "admin2"
-        outf = f"outputs{sep}unittests"
+        outf = output_path("unittests")
 
         # Process:
         df, dct = elwood.process(fp, mp, geo, outf)
@@ -434,10 +448,10 @@ class TestMixmaster(unittest.TestCase):
 
         # Load expected output:
         output_df = pd.read_csv(
-            f"outputs{sep}test7_single_band_tif_output.csv", index_col=False
+            output_path("test7_single_band_tif_output.csv"), index_col=False
         )
 
-        with open(f"outputs{sep}test7_single_band_tif_dict.json") as f:
+        with open(output_path("test7_single_band_tif_dict.json")) as f:
             output_dict = json.loads(f.read())
 
         # Sort both data frames and reindex for comparison,.
@@ -483,14 +497,14 @@ class TestMixmaster(unittest.TestCase):
         """This tests feature name aliases."""
 
         # Define elwood inputs:
-        mp = f"inputs{sep}test8_aliases_input.json"
-        fp = f"inputs{sep}test8_aliases_input.csv"
+        mp = input_path("test8_aliases_input.json")
+        fp = input_path("test8_aliases_input.csv")
         geo = "admin2"
-        outf = f"outputs{sep}unittests"
+        outf = output_path("unittests")
 
         inputs = (
-            '--inputs=[{"input_file": "inputs'
-            + f'{sep}test8_aliases_input.csv","mapper": "inputs{sep}test8_aliases_input.json"'
+            '--inputs=[{"input_file": "'
+            + f'{input_path("test8_aliases_input.csv")}","mapper": "{input_path("test8_aliases_input.json")}"'
             + "}]"
         )
         result = subprocess.run(
@@ -499,7 +513,7 @@ class TestMixmaster(unittest.TestCase):
                 "causemosify-multi",
                 inputs,
                 "--geo=admin2",
-                f"--output-file=outputs{sep}unittests",
+                f"--output-file={output_path('unittests')}",
             ],
             capture_output=True,
             encoding="utf-8",
@@ -510,12 +524,12 @@ class TestMixmaster(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
 
         ## Compare parquet files.
-        df1 = pd.read_parquet(f"outputs{sep}unittests.1.parquet.gzip")
-        df2 = pd.read_parquet(f"outputs{sep}unittests_str.1.parquet.gzip")
+        df1 = pd.read_parquet(output_path("unittests.1.parquet.gzip"))
+        df2 = pd.read_parquet(output_path("unittests_str.1.parquet.gzip"))
         df = df1.append(df2)
 
-        output_df_1 = pd.read_parquet(f"outputs{sep}test8_aliases.parquet.gzip")
-        output_df_2 = pd.read_parquet(f"outputs{sep}test8_aliases_str.parquet.gzip")
+        output_df_1 = pd.read_parquet(output_path("test8_aliases.parquet.gzip"))
+        output_df_2 = pd.read_parquet(output_path("test8_aliases_str.parquet.gzip"))
         output_df = output_df_1.append(output_df_2)
 
         print(f"TEST 8 {df}")

--- a/tests/elwood_unit_test.py
+++ b/tests/elwood_unit_test.py
@@ -11,26 +11,23 @@ import gc
 import os
 
 from pathlib import Path
+from os.path import join as path_join
 
 from elwood import elwood
 from pandas.util.testing import assert_frame_equal, assert_dict_equal
 import pandas as pd
 
+logger = logging.getLogger(__name__)
+
+
 def get_project_root() -> Path:
     return Path(__file__).parent.parent
 
-logger = logging.getLogger(__name__)
-
-from os.path import join as path_join
-
-inputs_base_dir = path_join(get_project_root(), "tests", "inputs")
-outputs_base_dir = path_join(get_project_root(), "tests", "outputs")
-
 def input_path(filename):
-    return path_join(inputs_base_dir, filename)
+    return path_join(get_project_root(), "tests", "inputs", filename)
 
 def output_path(filename):
-    return path_join(outputs_base_dir, filename)
+    return path_join(get_project_root(), "tests", "outputs", filename)
 
 
 class TestMixmaster(unittest.TestCase):
@@ -49,13 +46,11 @@ class TestMixmaster(unittest.TestCase):
         try:
             os.remove(output_path("unittests.parquet.gzip"))
         except FileNotFoundError as e:
-            # print(f"tearDown: Exception caught while trying to empty test output files: {type(e)}")
             pass
 
         try:
             os.remove(output_path("unittests_str.parquet.gzip"))
         except FileNotFoundError as e:
-            # print(f"tearDown: Exception caught while trying to empty test output files: {type(e)}")
             pass
 
     def test_001_process(self):


### PR DESCRIPTION
Removed ugly OS-driven manual `sep` (separator) variable. Added ability to run tests from root dir (or elsewhere), since input/output files are now looked relative from elwood_unit_test.py file.

To test this, I rebuilt the docker image and ran the tests both from root-project-dir and under the tests/ folder.